### PR TITLE
feat: Add union() function + enable number & boolean literals

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -259,22 +259,36 @@ function intersection([speckA, speckB]) {
 
 /**
  * A speck that could be one thing or another. Equivalent to `|` in TypeScript 
- * https://www.typescriptlang.org/docs/handbook/advanced-types.html#union-types)
- *g
- * Example:
+ * (https://www.typescriptlang.org/docs/handbook/advanced-types.html#union-types).
+ *
+ * This function is defined specifically for objects. This means that it is
+ * not possible to use a non-object speck as one of the parameters. This means
+ * that its return value will certainly be an object speck.
+ *
+ * This is important as intersection() can only meaningfully work on
+ * ObjectSpecks (e.g. what's the intersection between `3` and
+ * `{ x: number }`? No value could satisfy that intersection, so it's
+ * meaningless).
  * 
+ * Therefore, by doing this, we ensure that intersection, which only
+ * accepts ObjectSpecks, will never be given specks by this function that have
+ * any chance of not representing objects (e.g. this disallows
+ * `'hi' | { x: number }` from being given as an input to intersection()).
+ *
+ * TODO Create a non-object union function
+ *
+ * Example:
+ *
  * ```js
  * > var s = require('./lib')
- * > var HiOrBye = s.union([s.literal('hi'), s.literal('bye')])
+ * > const HiOrBye = s.unionObjects([ s.type({ hi: s.literal(true) }), s.type({ bye: s.literal(true) }) ]);
  * > s.gen(HiOrBye)
- * 'bye'
+ * { hi: true }
  * > s.gen(HiOrBye)
- * 'hi'
- * > s.gen(HiOrBye)
- * 'hi'
- * > s.validate(HiOrBye, 'hii')
+ * { bye: true }
+ * > s.validate(HiOrBye, { hey: true })
  * { Error: SpeckValidationErrors
- *     at Object.validate (/Volumes/IMIN VHD/Dev/speck/lib/index.js:360:12)
+ *     at Object.validate (/Volumes/IMIN VHD/Dev/speck/lib/index.js:416:12)
  *     at repl:1:3
  *     at Script.runInThisContext (vm.js:122:20)
  *     at REPLServer.defaultEval (repl.js:332:29)
@@ -285,33 +299,23 @@ function intersection([speckA, speckB]) {
  *     at REPLServer.EventEmitter.emit (domain.js:448:20)
  *     at REPLServer.Interface._onLine (readline.js:308:10)
  *   errors:
- *    [ { value: 'hii', context: [Array], message: undefined },
- *      { value: 'hii', context: [Array], message: undefined } ] }
- * > s.validate(HiOrBye, 'hi')
- * 'hi'
- * > s.validate(HiOrBye, 'bye')
- * 'bye'
+ *    [ { value: undefined, context: [Array], message: undefined },
+ *      { value: undefined, context: [Array], message: undefined } ] }
+ * > s.validate(HiOrBye, { hi: true })
+ * { hi: true }
+ * > s.validate(HiOrBye, { bye: true })
+ * { bye: true }
  * ```
  *
- * @template {import('./types').Speck<any>} TA
- * @template {import('./types').Speck<any>} TB
+ * @template {import('./types').ObjectSpeck<any>} TA
+ * @template {import('./types').ObjectSpeck<any>} TB
  * @param {[TA, TB]} specks
- * @returns {import('./types').UnionType<[TA, TB]>}
+ * @returns {import('./types').UnionObjectsType<[TA, TB]>}
  */
-function union([speckA, speckB]) {
+function unionObjects([speckA, speckB]) {
   const ioTsType = t.union([speckA._ioTsType, speckB._ioTsType]);
   const fastCheckArbitrary = fc.oneof(speckA._fastCheckArbitrary, speckB._fastCheckArbitrary);
-  if (speckA._isObjectType && speckB._isObjectType) {
-    // TODO not have to cast. If I do not use this case, TS gives error:
-    // > Type 'ObjectSpeck<any, any>' is not assignable to type 'UnionType<[TA, TB]>'
-    // No more detail than that..
-    return /** @type {import('./types').UnionType<[TA, TB]>} */(createObjectSpeck(ioTsType, fastCheckArbitrary));
-  } else {
-    // TODO not have to cast. If I do not use this case, TS gives error:
-    // > Type 'NonObjectSpeck<any, any>' is not assignable to type 'UnionType<[TA, TB]>'
-    // No more detail than that..
-    return /** @type {import('./types').UnionType<[TA, TB]>} */(createNonObjectSpeck(ioTsType, fastCheckArbitrary));
-  }
+  return createObjectSpeck(ioTsType, fastCheckArbitrary);
 }
 
 /**
@@ -414,7 +418,7 @@ module.exports = {
   type,
   partial,
   intersection,
-  union,
+  unionObjects,
   pickRequireds,
   // API functions
   gen,

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -76,24 +76,32 @@ export type PartialType<TRecordOfSpecks extends _BaseRecordOfSpecks> = ObjectSpe
 export type IntersectionType<TObjectSpecks extends [ObjectSpeck<any>, ObjectSpeck<any>]> =
   ObjectSpeck<TypeOf<TObjectSpecks[0]> & TypeOf<TObjectSpecks[1]>>;
 
-export type UnionType<TSpecks extends [Speck<any>, Speck<any>]> =
-  TSpecks[0] extends ObjectSpeck<any>
-    ? (TSpecks[1] extends ObjectSpeck<any>
-      // iff both specks are ObjectSpecks, then the result will be an
-      // ObjectSpeck. Otherwise, the result will be a NonObjectSpeck.
-      //
-      // This is important as intersection() can only meaningfully work on
-      // ObjectSpecks (e.g. what's the intersection between `3` and
-      // `{ x: number }`? No value could satisfy that intersection, so it's
-      // meaningless).
-      //
-      // Therefore, by doing this, we ensure that intersection, which only
-      // accepts ObjectSpecks, will never be given specks that have any chance
-      // of not representing objects (e.g. this disallows
-      // `'hi' | { x: number }` from being given as an input to intersection()).
-      ? ObjectSpeck<TypeOf<TSpecks[0]> | TypeOf<TSpecks[1]>>
-      : NonObjectSpeck<TypeOf<TSpecks[0]> | TypeOf<TSpecks[1]>>)
-    : NonObjectSpeck<TypeOf<TSpecks[0]> | TypeOf<TSpecks[1]>>;
+// A glimpse into what a better world could look like. Alas, I was not able to
+// get this to work:
+//
+// ```ts
+// export type UnionType<TSpecks extends [Speck<any>, Speck<any>]> =
+//   TSpecks[0] extends ObjectSpeck<any>
+//     ? (TSpecks[1] extends ObjectSpeck<any>
+//       // iff both specks are ObjectSpecks, then the result will be an
+//       // ObjectSpeck. Otherwise, the result will be a NonObjectSpeck.
+//       //
+//       // This is important as intersection() can only meaningfully work on
+//       // ObjectSpecks (e.g. what's the intersection between `3` and
+//       // `{ x: number }`? No value could satisfy that intersection, so it's
+//       // meaningless).
+//       //
+//       // Therefore, by doing this, we ensure that intersection, which only
+//       // accepts ObjectSpecks, will never be given specks that have any chance
+//       // of not representing objects (e.g. this disallows
+//       // `'hi' | { x: number }` from being given as an input to intersection()).
+//       ? ObjectSpeck<TypeOf<TSpecks[0]> | TypeOf<TSpecks[1]>>
+//       : NonObjectSpeck<TypeOf<TSpecks[0]> | TypeOf<TSpecks[1]>>)
+//     : NonObjectSpeck<TypeOf<TSpecks[0]> | TypeOf<TSpecks[1]>>;
+// ```
+
+export type UnionObjectsType<TObjectSpecks extends [ObjectSpeck<any>, ObjectSpeck<any>]> =
+  ObjectSpeck<TypeOf<TObjectSpecks[0]> | TypeOf<TObjectSpecks[1]>>;
 
 // # io-ts Brand types
 


### PR DESCRIPTION
## QA

**[NEW] unionObjects**

TS

![Screenshot 2020-01-28 at 13 38 26](https://user-images.githubusercontent.com/2067438/73269906-990fa400-41d5-11ea-87b3-43b40c7f2124.png)

gen/validate:

```js
 > var s = require('./lib')
 > const HiOrBye = s.unionObjects([ s.type({ hi: s.literal(true) }), s.type({ bye: s.literal(true) }) ]);
 > s.gen(HiOrBye)
 { hi: true }
 > s.gen(HiOrBye)
 { bye: true }
 > s.validate(HiOrBye, { hey: true })
 { Error: SpeckValidationErrors
     at Object.validate (/Volumes/IMIN VHD/Dev/speck/lib/index.js:416:12)
     at repl:1:3
     at Script.runInThisContext (vm.js:122:20)
     at REPLServer.defaultEval (repl.js:332:29)
     at bound (domain.js:402:14)
     at REPLServer.runBound [as eval] (domain.js:415:12)
     at REPLServer.onLine (repl.js:642:10)
     at REPLServer.emit (events.js:203:15)
     at REPLServer.EventEmitter.emit (domain.js:448:20)
     at REPLServer.Interface._onLine (readline.js:308:10)
   errors:
    [ { value: undefined, context: [Array], message: undefined },
      { value: undefined, context: [Array], message: undefined } ] }
 > s.validate(HiOrBye, { hi: true })
 { hi: true }
 > s.validate(HiOrBye, { bye: true })
 { bye: true }
```

**[OLD]**

TS

![Screenshot 2020-01-28 at 13 12 53](https://user-images.githubusercontent.com/2067438/73266979-ef79e400-41cf-11ea-8b4b-c959386ee7bc.png)

gen/validate

```
> var s = require('./lib')
undefined
> var HiOrBye = s.union([s.literal('hi'), s.literal('bye')])
> s.gen(HiOrBye)
'bye'
> s.gen(HiOrBye)
'hi'
> s.gen(HiOrBye)
'hi'
> s.validate(HiOrBye, 'hii')
{ Error: SpeckValidationErrors
    at Object.validate (/Volumes/IMIN VHD/Dev/speck/lib/index.js:360:12)
    at repl:1:3
    at Script.runInThisContext (vm.js:122:20)
    at REPLServer.defaultEval (repl.js:332:29)
    at bound (domain.js:402:14)
    at REPLServer.runBound [as eval] (domain.js:415:12)
    at REPLServer.onLine (repl.js:642:10)
    at REPLServer.emit (events.js:203:15)
    at REPLServer.EventEmitter.emit (domain.js:448:20)
    at REPLServer.Interface._onLine (readline.js:308:10)
  errors:
   [ { value: 'hii', context: [Array], message: undefined },
     { value: 'hii', context: [Array], message: undefined } ] }
> s.validate(HiOrBye, 'hi')
'hi'
> s.validate(HiOrBye, 'bye')
'bye'
```
